### PR TITLE
Add TidyType POC web assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# tidytype-webapp
+# TidyType Web Assistant
+
+TidyType is a simple web assistant that helps rewrite text with clarifications,
+fetch information about programming concepts, answer technical questions from
+Stack Overflow, and check code snippets for syntax errors. The project consists
+of a small Flask backend and a vanilla JavaScript frontend.
+
+## Running Locally
+
+1. **Install backend dependencies**
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. **Start the Flask server**
+   ```bash
+   python backend/app.py
+   ```
+3. **Open the frontend**
+   Use any static server or open `frontend/index.html` directly in your
+   browser while the backend is running.
+
+This is a minimal proof of concept intended for demonstration purposes.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,80 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import requests
+import traceback
+
+app = Flask(__name__)
+CORS(app)
+
+# Simple dictionary for rewriting common terms
+REWRITE_MAP = {
+    'flask': 'Flask (Python web framework)',
+    'react': 'React (JavaScript UI library)',
+    'node': 'Node.js runtime',
+    'django': 'Django (Python web framework)'
+}
+
+@app.route('/api/rewrite', methods=['POST'])
+def rewrite_text():
+    data = request.get_json(force=True)
+    text = data.get('text', '')
+    rewritten = ' '.join(REWRITE_MAP.get(word.lower(), word) for word in text.split())
+    return jsonify({'rewritten': rewritten})
+
+@app.route('/api/clarify')
+def clarify_concept():
+    concept = request.args.get('concept', '')
+    if not concept:
+        return jsonify({'error': 'Missing concept'}), 400
+    try:
+        url = 'https://en.wikipedia.org/api/rest_v1/page/summary/' + concept
+        resp = requests.get(url, timeout=5)
+        if resp.ok:
+            data = resp.json()
+            summary = data.get('extract', 'No summary found.')
+            return jsonify({'summary': summary})
+    except Exception:
+        traceback.print_exc()
+    return jsonify({'error': 'Could not fetch clarification.'}), 500
+
+@app.route('/api/answer')
+def answer_question():
+    query = request.args.get('q', '')
+    if not query:
+        return jsonify({'error': 'Missing query'}), 400
+    try:
+        params = {
+            'order': 'desc',
+            'sort': 'relevance',
+            'accepted': 'True',
+            'site': 'stackoverflow',
+            'title': query,
+            'filter': 'withbody',
+            'pagesize': 1
+        }
+        resp = requests.get('https://api.stackexchange.com/2.3/search/advanced', params=params, timeout=5)
+        if resp.ok:
+            data = resp.json()
+            if data.get('items'):
+                item = data['items'][0]
+                answer = {
+                    'title': item.get('title'),
+                    'link': item.get('link')
+                }
+                return jsonify({'answer': answer})
+    except Exception:
+        traceback.print_exc()
+    return jsonify({'error': 'Could not fetch answer.'}), 500
+
+@app.route('/api/debug', methods=['POST'])
+def debug_code():
+    data = request.get_json(force=True)
+    code = data.get('code', '')
+    try:
+        compile(code, '<string>', 'exec')
+        return jsonify({'result': 'No syntax errors detected.'})
+    except SyntaxError as e:
+        return jsonify({'result': f'Syntax error: {e}'})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask_cors
+requests

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TidyType Assistant</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 2rem;}
+    textarea {width: 100%; height: 80px;}
+    input[type=text] {width: 100%;}
+    .section {margin-bottom: 2rem;}
+  </style>
+</head>
+<body>
+  <h1>TidyType Assistant</h1>
+
+  <div class="section" id="rewrite">
+    <h2>Rewrite Text</h2>
+    <textarea id="rewrite-input" placeholder="Enter text..."></textarea>
+    <button onclick="rewrite()">Rewrite</button>
+    <pre id="rewrite-output"></pre>
+  </div>
+
+  <div class="section" id="clarify">
+    <h2>Clarify Concept</h2>
+    <input id="clarify-input" placeholder="Concept (e.g., Flask)" />
+    <button onclick="clarify()">Clarify</button>
+    <pre id="clarify-output"></pre>
+  </div>
+
+  <div class="section" id="answer">
+    <h2>Technical Question</h2>
+    <input id="question-input" placeholder="Ask a question" />
+    <button onclick="answer()">Ask</button>
+    <pre id="answer-output"></pre>
+  </div>
+
+  <div class="section" id="debug">
+    <h2>Debug Code</h2>
+    <textarea id="debug-input" placeholder="Enter code snippet..."></textarea>
+    <button onclick="debugCode()">Check</button>
+    <pre id="debug-output"></pre>
+  </div>
+
+  <script>
+    async function rewrite() {
+      const text = document.getElementById('rewrite-input').value;
+      const resp = await fetch('/api/rewrite', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text})
+      });
+      const data = await resp.json();
+      document.getElementById('rewrite-output').textContent = data.rewritten || data.error;
+    }
+
+    async function clarify() {
+      const concept = document.getElementById('clarify-input').value;
+      const resp = await fetch('/api/clarify?concept=' + encodeURIComponent(concept));
+      const data = await resp.json();
+      document.getElementById('clarify-output').textContent = data.summary || data.error;
+    }
+
+    async function answer() {
+      const q = document.getElementById('question-input').value;
+      const resp = await fetch('/api/answer?q=' + encodeURIComponent(q));
+      const data = await resp.json();
+      if (data.answer) {
+        document.getElementById('answer-output').textContent = data.answer.title + '\n' + data.answer.link;
+      } else {
+        document.getElementById('answer-output').textContent = data.error;
+      }
+    }
+
+    async function debugCode() {
+      const code = document.getElementById('debug-input').value;
+      const resp = await fetch('/api/debug', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({code})
+      });
+      const data = await resp.json();
+      document.getElementById('debug-output').textContent = data.result || data.error;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a minimal Flask backend
- provide rewrite, clarify, answer and debug endpoints
- add a lightweight HTML frontend
- document how to run the app

## Testing
- `python -m py_compile backend/app.py`
- `pip install -r backend/requirements.txt`
- `python backend/app.py >/tmp/flask_test.log 2>&1 &`
- `curl -s http://localhost:5000/api/rewrite -H "Content-Type: application/json" -d '{"text":"Flask and React"}'`
- `curl -s http://localhost:5000/api/clarify?concept=Flask` *(fails: Could not fetch clarification)*
- `curl -s "http://localhost:5000/api/answer?q=flask"` *(fails: Could not fetch answer)*

------
https://chatgpt.com/codex/tasks/task_e_6888301ff7a88327b042cfdd1e09814a